### PR TITLE
Added parser.py to parse the OBJ files and extract face vertices as required for the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@ In order to compile include and link SDL 2
 entry point of program is in main.cpp
 
 Monkey.txt is a Wavefront OBJ of the monkey head created in Blender loaded into the program, Debug.txt is opened and modified by the Log class
+
+To render your own blender files, make sure that you do the following steps
+
+1. Add `Triangulate` modifier to all the objects in your blender
+2. Export the model in OBJ format
+3. Parse the faces using the `parser.py` file as follows
+
+`parser.py <your model obj file> <new name for your parsed obj file>`
+
+4. To render it, run `./main <parsed obj file name>`

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,39 @@
+import sys
+
+try:
+	filename = sys.argv[1]
+	new_filename = sys.argv[2]
+
+	buffer = []
+	faces = []
+
+	with open(filename, "r") as f:
+		buffer = f.readlines();
+		buffer = [line.rstrip() for line in buffer]
+		f.close()
+
+	for line in buffer:
+		if 'f' in line and '#' not in line:
+			line = line.replace("f ", "")
+			faces.append(line)
+
+	with open(new_filename, "w") as f:
+		for line in buffer:
+			if 'f' not in line and '#' not in line:
+				f.write(line + "\n")
+
+		for line in faces:
+			try:
+				face = line.split(" ")
+				
+				s = "f " + face[0].split("/")[0] + " " + face[1].split("/")[0] + " " + face[2].split("/")[0] + "\n";
+
+				print(s)
+				f.write(s)
+			except:
+				pass
+
+		f.close()
+
+except:
+	print("Usage: python parser.py <OBJ file> <new OBJ file>")


### PR DESCRIPTION
`parser.py` file will extract the face vertices which is must for this code render it in the wireframe view. It extracts the faces from obj files, for example, if a face has the following line `f 12/22/30 30/11/45 88/22/35` then the parser will extract it as `f 12 30 88` and save it in the new file. This will help in opening any model with this renderer easily.

Also, modified README